### PR TITLE
fix for role-based permissions in hassio

### DIFF
--- a/remote-backup/config.json
+++ b/remote-backup/config.json
@@ -7,6 +7,7 @@
   "startup": "once",
   "boot": "manual",
   "hassio_api": true,
+  "hassio_role": "manager",
   "map": ["backup:rw"],
   "options": {
     "ssh_host": "",


### PR DESCRIPTION
Adding `"hassio_role": "manager",` to config.json solves issue #9

https://github.com/home-assistant/hassio/issues/692

Thanks @circuuz for the find.