### PR TITLE
Add optional ciphers to ssh config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See my [repository of addons][hassio-addons] for more information.
 |`remote_directory`|Yes|The directory to put the backups on the remote server.|
 |`zip_password`|No|If set then the backup will be contained in a password protected zip|
 |`keep_local_backup`|No|Control how many local backups you want to preserve. Default (`""`) is to keep no local backups created from this addon. If `all` then all loocal backups will be preserved. A positive integer will determine how many of the latest backups will be preserved. Note this will delete other local backups created outside this addon.
+|`ssh_ciphers`|No|Optional ciphers to use for `SCP`. e.g. `aes128-cbc,3des-cbc`  This is useful if you need to connect to a machine running an old version of ssh server.|
 
 ## <a name='example'></a>Example: daily backups at 4 AM
 

--- a/remote-backup/config.json
+++ b/remote-backup/config.json
@@ -10,6 +10,7 @@
   "hassio_role": "backup",
   "map": ["backup:rw"],
   "options": {
+    "ssh_cipher": "",
     "ssh_host": "",
     "ssh_port": 22,
     "ssh_user": "",
@@ -19,6 +20,7 @@
     "keep_local_backup": ""
   },
   "schema": {
+    "ssh_cipher": "str",
     "ssh_host": "str",
     "ssh_port": "int",
     "ssh_user": "str",

--- a/remote-backup/config.json
+++ b/remote-backup/config.json
@@ -10,7 +10,7 @@
   "hassio_role": "backup",
   "map": ["backup:rw"],
   "options": {
-    "ssh_cipher": "",
+    "ssh_ciphers": "",
     "ssh_host": "",
     "ssh_port": 22,
     "ssh_user": "",
@@ -20,7 +20,7 @@
     "keep_local_backup": ""
   },
   "schema": {
-    "ssh_cipher": "str",
+    "ssh_ciphers": "str",
     "ssh_host": "str",
     "ssh_port": "int",
     "ssh_user": "str",

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -33,7 +33,6 @@ function add-ssh-key {
         echo "$line" >> ${HOME}/.ssh/id
     done <<< "$SSH_KEY"
  
-    echo "$(cat ~/.ssh/config)"
     chmod 600 "${HOME}/.ssh/config"
     chmod 600 "${HOME}/.ssh/id"
 }

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -4,7 +4,7 @@ set -e
 CONFIG_PATH=/data/options.json
 
 # parse inputs from options
-SSH_CIPHER=$(jq --raw-output ".ssh_cipher" $CONFIG_PATH)
+SSH_CIPHERS=$(jq --raw-output ".ssh_ciphers" $CONFIG_PATH)
 SSH_HOST=$(jq --raw-output ".ssh_host" $CONFIG_PATH)
 SSH_PORT=$(jq --raw-output ".ssh_port" $CONFIG_PATH)
 SSH_USER=$(jq --raw-output ".ssh_user" $CONFIG_PATH)
@@ -26,7 +26,9 @@ function add-ssh-key {
         echo "    User ${SSH_USER}"
         echo "    Port ${SSH_PORT}"
         echo "    StrictHostKeyChecking no"
-        echo "    Ciphers ${SSH_CIPHER}"
+        if [ -n "$SSH_CIPHERS" ]; then
+            echo "    Ciphers ${SSH_CIPHER}"
+        fi
     ) > "${HOME}/.ssh/config"
 
     while read -r line; do

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -32,7 +32,8 @@ function add-ssh-key {
     while read -r line; do
         echo "$line" >> ${HOME}/.ssh/id
     done <<< "$SSH_KEY"
-
+ 
+    echo "$(cat ~/.ssh/config)"
     chmod 600 "${HOME}/.ssh/config"
     chmod 600 "${HOME}/.ssh/id"
 }

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -34,7 +34,7 @@ function add-ssh-key {
     while read -r line; do
         echo "$line" >> ${HOME}/.ssh/id
     done <<< "$SSH_KEY"
- 
+
     chmod 600 "${HOME}/.ssh/config"
     chmod 600 "${HOME}/.ssh/id"
 }

--- a/remote-backup/run.sh
+++ b/remote-backup/run.sh
@@ -4,6 +4,7 @@ set -e
 CONFIG_PATH=/data/options.json
 
 # parse inputs from options
+SSH_CIPHER=$(jq --raw-output ".ssh_cipher" $CONFIG_PATH)
 SSH_HOST=$(jq --raw-output ".ssh_host" $CONFIG_PATH)
 SSH_PORT=$(jq --raw-output ".ssh_port" $CONFIG_PATH)
 SSH_USER=$(jq --raw-output ".ssh_user" $CONFIG_PATH)
@@ -25,6 +26,7 @@ function add-ssh-key {
         echo "    User ${SSH_USER}"
         echo "    Port ${SSH_PORT}"
         echo "    StrictHostKeyChecking no"
+        echo "    Ciphers ${SSH_CIPHER}"
     ) > "${HOME}/.ssh/config"
 
     while read -r line; do


### PR DESCRIPTION
I tried using the addon, unfortunately my synology uses a very old version of ssh.  The only way to ssh into it from a hass.io install is to specify one of the ciphers it allows, e.g. `aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc`.  The changes in this PR would add an optional config item for specifying cipher(s) to put into the ssh config file.